### PR TITLE
Update @apollo/federation and replace printSchema with printSubgraphS…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@brooklyn-labs/postgraphile-plugin-apollo-federation",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@brooklyn-labs/postgraphile-plugin-apollo-federation",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
-        "@apollo/federation": "^0.33.0",
+        "@apollo/federation": "^0.33.9",
         "@graphql-tools/wrap": "^9.2.1",
         "@types/graphql": "^14.5.0",
         "graphile-utils": "^4.12.3"
@@ -55,11 +55,12 @@
       }
     },
     "node_modules/@apollo/federation": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.0.tgz",
-      "integrity": "sha512-Zywqb6Zv12/PVl7K/jtDgcJFghg02fqqDHyGbHBhf0+WdNvI9QqRvOY433BuZw/NYcRUbz9cPEAG5JCRB2K83w==",
+      "version": "0.33.9",
+      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.9.tgz",
+      "integrity": "sha512-Sbau1gvWN6/pJdw13xZCoQ75IQu6F6D9XkZ9FapMVX04bE1j1XXbYtSK+ZVZuOOCfMLnYV/iLEEPxedVb7+0yA==",
       "dependencies": {
-        "apollo-graphql": "^0.9.3",
+        "@apollo/subgraph": "^0.1.5",
+        "apollo-graphql": "^0.9.5",
         "apollo-server-types": "^3.0.2",
         "lodash.xorby": "^4.7.0"
       },
@@ -228,6 +229,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@apollo/subgraph": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-0.1.5.tgz",
+      "integrity": "sha512-i1uU9llldGMV7GcBOUQRqnbGfgOpc6nrOVw93oKlugZq5R00q8y/RX8KgvMfdXZyr4MJ2/gO6Kw7LzbjCKU+Kw==",
+      "dependencies": {
+        "apollo-graphql": "^0.9.5"
+      },
+      "engines": {
+        "node": ">=12.13.0 <17.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.3"
       }
     },
     "node_modules/@apollo/utils.dropunuseddefinitions": {
@@ -3038,9 +3053,9 @@
       }
     },
     "node_modules/apollo-graphql": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.3.tgz",
-      "integrity": "sha512-rcAl2E841Iko4kSzj4Pt3PRBitmyq1MvoEmpl04TQSpGnoVgl1E/ZXuLBYxMTSnEAm7umn2IsoY+c6Ll9U/10A==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.7.tgz",
+      "integrity": "sha512-bezL9ItUWUGHTm1bI/XzIgiiZbhXpsC7uxk4UxFPmcVJwJsDc3ayZ99oXxAaK+3Rbg/IoqrHckA6CwmkCsbaSA==",
       "dependencies": {
         "core-js-pure": "^3.10.2",
         "lodash.sortby": "^4.7.0",
@@ -10955,11 +10970,12 @@
       }
     },
     "@apollo/federation": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.0.tgz",
-      "integrity": "sha512-Zywqb6Zv12/PVl7K/jtDgcJFghg02fqqDHyGbHBhf0+WdNvI9QqRvOY433BuZw/NYcRUbz9cPEAG5JCRB2K83w==",
+      "version": "0.33.9",
+      "resolved": "https://registry.npmjs.org/@apollo/federation/-/federation-0.33.9.tgz",
+      "integrity": "sha512-Sbau1gvWN6/pJdw13xZCoQ75IQu6F6D9XkZ9FapMVX04bE1j1XXbYtSK+ZVZuOOCfMLnYV/iLEEPxedVb7+0yA==",
       "requires": {
-        "apollo-graphql": "^0.9.3",
+        "@apollo/subgraph": "^0.1.5",
+        "apollo-graphql": "^0.9.5",
         "apollo-server-types": "^3.0.2",
         "lodash.xorby": "^4.7.0"
       }
@@ -11084,6 +11100,14 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "@apollo/subgraph": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-0.1.5.tgz",
+      "integrity": "sha512-i1uU9llldGMV7GcBOUQRqnbGfgOpc6nrOVw93oKlugZq5R00q8y/RX8KgvMfdXZyr4MJ2/gO6Kw7LzbjCKU+Kw==",
+      "requires": {
+        "apollo-graphql": "^0.9.5"
       }
     },
     "@apollo/utils.dropunuseddefinitions": {
@@ -13249,9 +13273,9 @@
       }
     },
     "apollo-graphql": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.3.tgz",
-      "integrity": "sha512-rcAl2E841Iko4kSzj4Pt3PRBitmyq1MvoEmpl04TQSpGnoVgl1E/ZXuLBYxMTSnEAm7umn2IsoY+c6Ll9U/10A==",
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.7.tgz",
+      "integrity": "sha512-bezL9ItUWUGHTm1bI/XzIgiiZbhXpsC7uxk4UxFPmcVJwJsDc3ayZ99oXxAaK+3Rbg/IoqrHckA6CwmkCsbaSA==",
       "requires": {
         "core-js-pure": "^3.10.2",
         "lodash.sortby": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/brooklyn-labs/postgraphile-plugin-apollo-federation#readme",
   "dependencies": {
-    "@apollo/federation": "^0.33.0",
+    "@apollo/federation": "^0.33.9",
     "@graphql-tools/wrap": "^9.2.1",
     "@types/graphql": "^14.5.0",
     "graphile-utils": "^4.12.3"

--- a/src/printFederatedSchema.ts
+++ b/src/printFederatedSchema.ts
@@ -1,4 +1,4 @@
-import { printSchema } from "@apollo/federation";
+import { printSubgraphSchema } from "@apollo/subgraph";
 import { FilterTypes, TransformRootFields, wrapSchema } from "@graphql-tools/wrap";
 import { GraphQLSchema } from "graphql";
 
@@ -56,7 +56,7 @@ export default function printFederatedSchema(schema: GraphQLSchema): string {
     });
 
     // Print the schema, including the federation directives.
-    lastPrint = printSchema(schemaSansFederationFields);
+    lastPrint = printSubgraphSchema(schemaSansFederationFields);
   }
   return lastPrint;
 }


### PR DESCRIPTION
Update @apollo/federation. The `printSchema` function has been replaced by `printSubgraphSchema`.